### PR TITLE
Packages: PackageInstaller: only Shift4 signed packages are allowed

### DIFF
--- a/src/com/android/packageinstaller/PackageInstallerActivity.java
+++ b/src/com/android/packageinstaller/PackageInstallerActivity.java
@@ -587,20 +587,11 @@ public class PackageInstallerActivity extends OverlayTouchActivity implements On
             return;
         }
 
-        if (mAllowUnknownSources || !isInstallRequestFromUnknownSource(getIntent()) || isShift4Signed()) {
+        if (isShift4Signed()) {
             initiateInstall();
         } else {
             // Check for unknown sources restriction
-            final int unknownSourcesRestrictionSource = mUserManager.getUserRestrictionSource(
-                    UserManager.DISALLOW_INSTALL_UNKNOWN_SOURCES, Process.myUserHandle());
-            if ((unknownSourcesRestrictionSource & UserManager.RESTRICTION_SOURCE_SYSTEM) != 0) {
-                showDialogInner(DLG_UNKNOWN_SOURCES_RESTRICTED_FOR_USER);
-            } else if (unknownSourcesRestrictionSource != UserManager.RESTRICTION_NOT_SET) {
-                startActivity(new Intent(Settings.ACTION_SHOW_ADMIN_SUPPORT_DETAILS));
-                finish();
-            } else {
-                handleUnknownSources();
-            }
+            showDialogInner(DLG_UNKNOWN_SOURCES_RESTRICTED_FOR_USER);
         }
     }
 


### PR DESCRIPTION
Deny any packages installation except for Shift4 signed packages.
It does not depend on any system settings, hardcode logic.

Change-Id: Id532e91ef349ce40f63deccba9ee1e45956e03fd