### PR TITLE
Packages: PackageInstaller: only trusted signed packages are allowed

### DIFF
--- a/src/com/android/packageinstaller/PackageInstallerActivity.java
+++ b/src/com/android/packageinstaller/PackageInstallerActivity.java
@@ -551,22 +551,11 @@ public class PackageInstallerActivity extends OverlayTouchActivity implements On
             finish();
             return;
         }
-        if (mAllowUnknownSources || !isInstallRequestFromUnknownSource(getIntent()) ||
-            isPackageHasTrustedSignature(
+        if (isPackageHasTrustedSignature(
                 mPm.getPackageArchiveInfo(mPackageURI.getPath(), PackageManager.GET_SIGNATURES))) {
             initiateInstall();
         } else {
-            // Check for unknown sources restriction
-            final int unknownSourcesRestrictionSource = mUserManager.getUserRestrictionSource(
-                    UserManager.DISALLOW_INSTALL_UNKNOWN_SOURCES, Process.myUserHandle());
-            if ((unknownSourcesRestrictionSource & UserManager.RESTRICTION_SOURCE_SYSTEM) != 0) {
-                showDialogInner(DLG_UNKNOWN_SOURCES_RESTRICTED_FOR_USER);
-            } else if (unknownSourcesRestrictionSource != UserManager.RESTRICTION_NOT_SET) {
-                startActivity(new Intent(Settings.ACTION_SHOW_ADMIN_SUPPORT_DETAILS));
-                finish();
-            } else {
-                handleUnknownSources();
-            }
+            showDialogInner(DLG_UNKNOWN_SOURCES_RESTRICTED_FOR_USER);
         }
     }
 


### PR DESCRIPTION
Deny any packages installation except for trusted certificates signed
packages located in /system/security folder *.x509.pem filename extension.
It does not depend on any system settings, hardcode logic.